### PR TITLE
fix calendar styles

### DIFF
--- a/src/date-input.scss
+++ b/src/date-input.scss
@@ -5,5 +5,7 @@
     display: flex;
     flex-direction: column;
   }
-
+  .DayPicker-Month {
+    min-width: 260px;
+  }
 }

--- a/src/year-month-picker/year-month-picker.scss
+++ b/src/year-month-picker/year-month-picker.scss
@@ -2,7 +2,6 @@
   $arrows-width: 25px;
   $separator: 6px;
   padding: 0;
-  min-width: 260px;
 
   select {
     display: inline-block;


### PR DESCRIPTION
Min-width was assigned to a wrong container. Now calendar layout should look pretty much the same across all browsers.