### PR TITLE
Fixed: Calendar overlay now closes on input blur.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
-* Fixed: Calendar overlay now closes on input blur.
+* Fixed onBlur handler
 
 ## 3.2.4
 * Changed locale default en_GB -> en-GB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Fixed: Calendar overlay now closes on input blur.
 
 ## 3.2.4
 * Changed locale default en_GB -> en-GB

--- a/src/date-input.component.jsx
+++ b/src/date-input.component.jsx
@@ -122,6 +122,10 @@ export default class DateInput extends React.Component {
 
     this.input = null;
     this.dayPicker = null;
+
+    // Used in onBlur handler to determine whether or not blur happened because of a click
+    // on the overlay
+    this.mouseClickedOnContainer = false;
   }
 
   componentWillUnmount() {
@@ -212,6 +216,15 @@ export default class DateInput extends React.Component {
 
   handleInputBlur = () => {
     this.prettifyInputDate();
+
+    // We want to close the overlay on blur, unless it was caused by a click on the calendar
+    // overlay
+    if (!this.mouseClickedOnContainer) {
+      this.setState({
+        showOverlay: false,
+      });
+    }
+    this.mouseClickedOnContainer = false;
   };
 
   /**
@@ -269,36 +282,6 @@ export default class DateInput extends React.Component {
     });
   };
 
-  /**
-   * Handles certain key presses and things that cannot be done using onBlur
-   * handler
-   * @param e
-   */
-  handleKeyDown = (e) => {
-    const val = this.input.value;
-    switch (e.keyCode) {
-      case 9: // tab
-      case 27: // esc
-        this.setState({ showOverlay: false });
-        break;
-      case 37: // arrow left
-      case 38: // arrow up
-      case 39: // arrow right
-      case 40: // arrow down
-        // In @opuscapita/react-grid we want to close the overlay, if all the text in
-        // input is selected and arrow key is pressed. If someone knows how to implement
-        // a proper onBlur handler that will work seamlessly with the calendar overlay,
-        // please do so.
-        if (val === val.substring(this.input.selectionStart, this.input.selectionEnd)) {
-          this.setState({ showOverlay: false }, () => {
-            this.input.blur();
-          });
-        }
-        break;
-      default:
-        break;
-    }
-  };
 
   /**
    * Handles year-month picker (select boxes) change
@@ -320,6 +303,11 @@ export default class DateInput extends React.Component {
     });
   };
 
+  onCalendar = (e) => {
+    if (this.calendarContainer.contains(e.target)) {
+      this.mouseClickedOnContainer = true;
+    }
+  };
   /**
    * Checks whether or not selected day is same as a day in calendar
    * Used by dayPicker
@@ -410,7 +398,6 @@ export default class DateInput extends React.Component {
             onChange={this.handleInputChange}
             onFocus={this.handleInputFocus}
             onBlur={this.handleInputBlur}
-            onKeyDown={this.handleKeyDown}
           />
         </FormGroup>
         {this.state.showOverlay &&
@@ -420,6 +407,7 @@ export default class DateInput extends React.Component {
           ref={(el) => {
             this.calendarContainer = el;
           }}
+          onMouseDown={this.onCalendar}
         >
           <DayPicker
             {...otherProps}

--- a/src/date-input.component.jsx
+++ b/src/date-input.component.jsx
@@ -47,7 +47,8 @@ export default class DateInput extends React.Component {
     locale: 'en-GB',
     onChange() {
     },
-    onDayClick: () => {},
+    onDayClick: () => {
+    },
     inputProps: {},
     inputRef() {
     },
@@ -113,7 +114,10 @@ export default class DateInput extends React.Component {
 
     this.localeUtils = Object.assign(
       LocaleUtils,
-      { getFirstDayOfWeek: () => moment.localeData().firstDayOfWeek() },
+      {
+        getFirstDayOfWeek: () => moment.localeData()
+          .firstDayOfWeek()
+      },
     );
 
     this.input = null;
@@ -144,7 +148,8 @@ export default class DateInput extends React.Component {
    * Returns the first of the week based on locale (used by DayPicker)
    * @returns {number}
    */
-  getFirstDayOfWeek = () => moment.localeData(this.props.locale).firstDayOfWeek();
+  getFirstDayOfWeek = () => moment.localeData(this.props.locale)
+    .firstDayOfWeek();
 
   /**
    * Handles input focus event. Shows an overlay and adds an click event listener to the document
@@ -189,7 +194,8 @@ export default class DateInput extends React.Component {
 
     this.setState({ inputDate });
     // This fires only if the new date is valid in given format
-    if (moment.utc(inputDate, dateFormat).isValid() && this.isValidFormat(inputDate)) {
+    if (moment.utc(inputDate, dateFormat)
+      .isValid() && this.isValidFormat(inputDate)) {
       this.setState({
         selectedDay: DateInput.getDate(inputDate, FORMATS.DATE_OBJECT, dateFormat),
       }, () => {
@@ -206,7 +212,8 @@ export default class DateInput extends React.Component {
 
   handleInputBlur = () => {
     this.prettifyInputDate();
-  }
+    this.setState({ showOverlay: false });
+  };
 
   /**
    * Handles dayPicker click
@@ -219,7 +226,8 @@ export default class DateInput extends React.Component {
     const momentDate = moment.utc(day);
 
     let timeAdjustedDate = null;
-    const currentMomentDate = moment(value, moment.ISO_8601).utc();
+    const currentMomentDate = moment(value, moment.ISO_8601)
+      .utc();
     const currentHours = currentMomentDate.get('hour');
     const currentMinutes = currentMomentDate.get('minute');
 
@@ -270,7 +278,8 @@ export default class DateInput extends React.Component {
     const { value, dateFormat } = this.props;
     const momentDate = value ? moment.utc(value, moment.ISO_8601) : moment.utc();
 
-    momentDate.year(val.getFullYear()).month(val.getMonth());
+    momentDate.year(val.getFullYear())
+      .month(val.getMonth());
 
     this.setState({
       inputDate: DateInput.getDate(momentDate, FORMATS.PRETTY_DATE, dateFormat),
@@ -306,7 +315,7 @@ export default class DateInput extends React.Component {
     this.setState({
       inputDate: DateInput.getDate(momentDate, FORMATS.PRETTY_DATE, dateFormat),
     });
-  }
+  };
 
   /**
    * Renders select boxes above the calendar

--- a/src/date-input.component.jsx
+++ b/src/date-input.component.jsx
@@ -303,11 +303,16 @@ export default class DateInput extends React.Component {
     });
   };
 
-  onCalendar = (e) => {
+  /**
+   * Handles a click on the overlay
+   * @param e
+   */
+  handleOnOverlayMouseDown = (e) => {
     if (this.calendarContainer.contains(e.target)) {
       this.mouseClickedOnContainer = true;
     }
   };
+
   /**
    * Checks whether or not selected day is same as a day in calendar
    * Used by dayPicker
@@ -407,7 +412,7 @@ export default class DateInput extends React.Component {
           ref={(el) => {
             this.calendarContainer = el;
           }}
-          onMouseDown={this.onCalendar}
+          onMouseDown={this.handleOnOverlayMouseDown}
         >
           <DayPicker
             {...otherProps}

--- a/src/date-input.component.jsx
+++ b/src/date-input.component.jsx
@@ -116,7 +116,7 @@ export default class DateInput extends React.Component {
       LocaleUtils,
       {
         getFirstDayOfWeek: () => moment.localeData()
-          .firstDayOfWeek()
+          .firstDayOfWeek(),
       },
     );
 
@@ -212,7 +212,6 @@ export default class DateInput extends React.Component {
 
   handleInputBlur = () => {
     this.prettifyInputDate();
-    this.setState({ showOverlay: false });
   };
 
   /**
@@ -268,6 +267,37 @@ export default class DateInput extends React.Component {
     }, () => {
       this.props.onChange(DateInput.getDate(momentDate, FORMATS.UTC, dateFormat));
     });
+  };
+
+  /**
+   * Handles certain key presses and things that cannot be done using onBlur
+   * handler
+   * @param e
+   */
+  handleKeyDown = (e) => {
+    const val = this.input.value;
+    switch (e.keyCode) {
+      case 9: // tab
+      case 27: // esc
+        this.setState({ showOverlay: false });
+        break;
+      case 37: // arrow left
+      case 38: // arrow up
+      case 39: // arrow right
+      case 40: // arrow down
+        // In @opuscapita/react-grid we want to close the overlay, if all the text in
+        // input is selected and arrow key is pressed. If someone knows how to implement
+        // a proper onBlur handler that will work seamlessly with the calendar overlay,
+        // please do so.
+        if (val === val.substring(this.input.selectionStart, this.input.selectionEnd)) {
+          this.setState({ showOverlay: false }, () => {
+            this.input.blur();
+          });
+        }
+        break;
+      default:
+        break;
+    }
   };
 
   /**
@@ -380,6 +410,7 @@ export default class DateInput extends React.Component {
             onChange={this.handleInputChange}
             onFocus={this.handleInputFocus}
             onBlur={this.handleInputBlur}
+            onKeyDown={this.handleKeyDown}
           />
         </FormGroup>
         {this.state.showOverlay &&


### PR DESCRIPTION
Fixed: Calendar overlay now closes on input blur.

(I also ran the code through Prettifier, but the actual fix is on line 215)