### PR TITLE
Fixed bug: if UTC offset is negative and UTC date differs from local …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Fixed bug: if UTC offset is negative and UTC date differs from local date, the day picker shows local date selected (day before UTC date) but the date input the UTC date.
 
 ## 3.6.0
 * Added `formatDate` prop

--- a/src/date-input.component.jsx
+++ b/src/date-input.component.jsx
@@ -103,7 +103,9 @@ export default class DateInput extends React.Component {
         return DateInput.removeInvisibleChars(momentDate.toISOString());
       case FORMATS.DATE_OBJECT:
       default:
-        return momentDate.toDate();
+        // UTC day might differ from local day, therefore UTC offset
+        // must be discounted.
+        return new Date(momentDate.format('L'));
     }
   }
 
@@ -289,7 +291,8 @@ export default class DateInput extends React.Component {
     const {
       dateFormat, formatDate, value, time,
     } = this.props;
-    const momentDate = moment.utc(day);
+    // UTC day might differ from local date therefore UTC offset must be discounted.
+    const momentDate = moment.utc(moment(day).format('L'));
 
     let timeAdjustedDate = null;
     const currentMomentDate = moment(value, moment.ISO_8601).utc();


### PR DESCRIPTION
…date, the day picker shows local date selected (day before UTC date) but the date input the UTC date